### PR TITLE
Convert P010/P016 hardware-decoder frames to 8-bit before analysis

### DIFF
--- a/mpeg2dec.c
+++ b/mpeg2dec.c
@@ -1347,7 +1347,10 @@ static int    prev_strange_framenum = 0;
     {
         frameFinished = 1;
         // convert to 8bit
-        if (is->pFrame->format == AV_PIX_FMT_YUV420P10LE) {
+        if (is->pFrame->format == AV_PIX_FMT_YUV420P10LE ||
+            is->pFrame->format == AV_PIX_FMT_P010LE ||
+            is->pFrame->format == AV_PIX_FMT_P016LE ||
+            is->pFrame->format == AV_PIX_FMT_YUV420P12LE) {
             is->img_convert_ctx = sws_getCachedContext(is->img_convert_ctx, is->pFrame->width, is->pFrame->height, is->pFrame->format, is->pFrame->width, is->pFrame->height, AV_PIX_FMT_YUV420P, SWS_POINT, NULL, NULL, NULL);
             AVFrame *newframe = av_frame_alloc();
             av_frame_copy_props(newframe, is->pFrame);


### PR DESCRIPTION
Hardware decoders emit `AV_PIX_FMT_P010LE` (not `AV_PIX_FMT_YUV420P10LE`) for 10-bit HEVC, so the 8-bit conversion added in #143 is skipped when decoding Main10 sources with `--cuvid`/`--qsv`-style hardware paths. The frame then falls through to the 8-bit code and is processed as a double-width 8-bit buffer of interleaved 10-bit sample bytes: for 1920x1080 Main10 input, `width` becomes `linesize[0] = 3840` and every visual metric (brightness, uniformity, logo matching) is computed over byte soup.

Symptoms observed on 1080p50 HEVC Main10 broadcast recordings with `hevc_qsv`:

- saved logo files carry `picWidth=3840` for 1920-wide video (a quick tell for affected setups)
- black-frame detection degrades (averaged interleaved bytes still loosely track luma, so results look plausible rather than obviously broken)
- logo detection auto-disables: `Not enough or too much logo's found (0.00), disabling the use of Logo detection`

This change extends the existing conversion to `P010LE`, `P016LE` and `YUV420P12LE`, mirroring what #143 already does for `YUV420P10LE` ("SubmitFrame uses `frame_ptr = pFrame->data[0]` and assumes 8-bit per pixel").

Validated on 65-minute Main10 recordings: `width` reports 1920 again, logo fraction went from 0.0000 (auto-disabled) to 0.42 with a working logo file, and commercial boundaries match a frame-by-frame manual audit of the same recording. May also be related to the HEVC pain reported in #181.
