### PR TITLE
Fix silently-broken pinned logo mask matching (stride corruption at load)

### DIFF
--- a/comskip.c
+++ b/comskip.c
@@ -870,6 +870,9 @@ int					clogoMaxX;
 int					clogoMinY;
 int					clogoMaxY;
 unsigned char choriz_edgemask[MAXHEIGHT*MAXWIDTH];
+int logo_mask_loaded_width = -1;   // stride the loaded mask cells are stored at;
+                                   // the live width global is rewritten by decode
+                                   // and analysis contexts and is 0 at load time
 unsigned char cvert_edgemask[MAXHEIGHT*MAXWIDTH];
 
 
@@ -11330,7 +11333,7 @@ double CheckStationLogoEdge(unsigned char* testFrame)
         {
             for (x = clogoMinX; x <= clogoMaxX; x += edge_step)
             {
-                index = y * width + x;
+                index = y * ((logo_mask_loaded_width > 0) ? logo_mask_loaded_width : width) + x;
                 if (choriz_edgemask[index])
                 {
                     if (TEST_HEDGE1(testFrame,x,y))
@@ -11357,7 +11360,7 @@ double CheckStationLogoEdge(unsigned char* testFrame)
         {
             for (x = clogoMinX; x <= clogoMaxX; x += edge_step)
             {
-                index = y * width + x;
+                index = y * ((logo_mask_loaded_width > 0) ? logo_mask_loaded_width : width) + x;
                 if (choriz_edgemask[index])
                 {
                     if (TEST_HEDGE2(testFrame,x,y))
@@ -11384,7 +11387,7 @@ double CheckStationLogoEdge(unsigned char* testFrame)
         {
             for (x = clogoMinX; x <= clogoMaxX; x += edge_step)
             {
-                index = y * width + x;
+                index = y * ((logo_mask_loaded_width > 0) ? logo_mask_loaded_width : width) + x;
                 if (choriz_edgemask[index])
                 {
                     if (TEST_HEDGE3(testFrame,x,y))
@@ -11411,7 +11414,7 @@ double CheckStationLogoEdge(unsigned char* testFrame)
         {
             for (x = clogoMinX; x <= clogoMaxX; x += edge_step)
             {
-                index = y * width + x;
+                index = y * ((logo_mask_loaded_width > 0) ? logo_mask_loaded_width : width) + x;
                 if (choriz_edgemask[index] && testFrame[index] < 200)
                 {
                     if (TEST_HEDGE0(testFrame,x,y))
@@ -11437,7 +11440,7 @@ double CheckStationLogoEdge(unsigned char* testFrame)
         {
             for (x = clogoMinX; x <= clogoMaxX; x += edge_step)
             {
-                index = y * width + x;
+                index = y * ((logo_mask_loaded_width > 0) ? logo_mask_loaded_width : width) + x;
                 if (choriz_edgemask[index])
                 {
                     if (TEST_HEDGE0(testFrame,x,y))
@@ -12033,6 +12036,7 @@ bool SearchForLogoEdges(void)
         clogoMaxY = tlogoMaxY;
         memcpy(choriz_edgemask, thoriz_edgemask, width * height);
         memcpy(cvert_edgemask, tvert_edgemask, width * height);
+        logo_mask_loaded_width = width;
 
 
         logoTrendCounter = num_logo_buffers;
@@ -12566,11 +12570,11 @@ void LoadLogoMaskData(void)
             switch (temp)
             {
             case ' ':
-                choriz_edgemask[y * width + x] = 0;
+                choriz_edgemask[y * MAXWIDTH + x] = 0;
                 break;
 
             case '|':
-                choriz_edgemask[y * width + x] = 1;
+                choriz_edgemask[y * MAXWIDTH + x] = 1;
                 break;
             }
         }
@@ -12592,11 +12596,11 @@ void LoadLogoMaskData(void)
             switch (temp)
             {
             case ' ':
-                cvert_edgemask[y * width + x] = 0;
+                cvert_edgemask[y * MAXWIDTH + x] = 0;
                 break;
 
             case '-':
-                cvert_edgemask[y * width + x] = 1;
+                cvert_edgemask[y * MAXWIDTH + x] = 1;
                 break;
             }
         }
@@ -12620,23 +12624,23 @@ void LoadLogoMaskData(void)
                 switch (temp)
                 {
                 case ' ':
-                    choriz_edgemask[y * width + x] = 0;
-                    cvert_edgemask[y * width + x] = 0;
+                    choriz_edgemask[y * MAXWIDTH + x] = 0;
+                    cvert_edgemask[y * MAXWIDTH + x] = 0;
                     break;
 
                 case '-':
-                    choriz_edgemask[y * width + x] = 0;
-                    cvert_edgemask[y * width + x] = 1;
+                    choriz_edgemask[y * MAXWIDTH + x] = 0;
+                    cvert_edgemask[y * MAXWIDTH + x] = 1;
                     break;
 
                 case '|':
-                    choriz_edgemask[y * width + x] = 1;
-                    cvert_edgemask[y * width + x] = 0;
+                    choriz_edgemask[y * MAXWIDTH + x] = 1;
+                    cvert_edgemask[y * MAXWIDTH + x] = 0;
                     break;
 
                 case '+':
-                    choriz_edgemask[y * width + x] = 1;
-                    cvert_edgemask[y * width + x] = 1;
+                    choriz_edgemask[y * MAXWIDTH + x] = 1;
+                    cvert_edgemask[y * MAXWIDTH + x] = 1;
                     break;
 
                 }
@@ -12646,6 +12650,7 @@ void LoadLogoMaskData(void)
     fclose(logo_file);
 
 
+    logo_mask_loaded_width = MAXWIDTH;
     logoInfoAvailable = true;
     startOverAfterLogoInfoAvail = true; // prevent continuous searching for logo when a logo file is specified
     secondLogoSearch = true;


### PR DESCRIPTION
Pinned logo masks (`--logo` / `use_existing_logo_file=1`) can silently fail to match anything, because mask cells are stored and looked up through the live `width` global, which is not stable:

1. `LoadLogoMaskData()` is called from output-file setup, before the first frame is decoded. Unless the logo file carries a `picWidth=` tag, `width` is still 0 at that point, so every cell is stored at `[y*0+x]` and the whole mask collapses onto row zero.
2. Even with `picWidth=` present, `width` is rewritten at runtime from decoder `linesize` and by the analysis code, and can differ between logo checks within a single run (observed: 3840 on the first check, 1920 on subsequent ones, with hardware decode). Any mismatch between the stride the mask was stored at and the stride used in `CheckStationLogoEdge` scatters the lookups.

The failure is invisible: `CheckStationLogoEdge` finds `testEdges == 0`, returns the 0.5 sentinel for every frame, the logo histogram degenerates into a single bucket (0.5 bins into the 0.450 label via `(int)(0.5*(buckets-1))`), and detection auto-disables with `Not enough or too much logo's found (0.00)`. Because learning-mode masks live in memory and work fine, tuning sessions look healthy and only the pinned deployment fails — which is what makes this hard to notice in the field.

Fix: store loaded mask cells at a fixed `MAXWIDTH` stride (the arrays are statically sized `MAXHEIGHT*MAXWIDTH`, so this always fits), record the storage stride in `logo_mask_loaded_width`, and index the mask through that stride in `CheckStationLogoEdge` while frame pixels keep using the live `width`. The learning path records its stride on the found-logo `memcpy` for the same reason.

Validation: a synthetic single-frame video with a known mask gives a predicted per-frame recall of 0.975 (computed externally with the same edge primitive); before this change comskip reports a constant 0.500 on it, after this change it reports 0.968. On real 65-minute recordings the logo histogram becomes bimodal (news ~0.95, commercials near 0) and commercial boundaries match a frame-by-frame manual audit, including break edges that black-frame detection alone cannot find.
